### PR TITLE
Use the top level gulp

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
  * Licensed under the MIT license.
  */
 
-var currentGulp = require('gulp')
+var currentGulp = require.main.require('gulp')
 var thunk = require('thunks')()
 var gutil = require('gulp-util')
 var packageName = require('./package.json').name


### PR DESCRIPTION
This allows use of `gulp-sequence` by modules that are symlinked, or modules that don't directly depend on gulp
