### PR TITLE
filter for undefined tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = sequence()
 function sequence (gulp) {
   function gulpSequence () {
     if (!gulp) gulp = require('gulp')
-    
+
     var BREAKER = {}
     var args = slice.call(arguments)
     var done = args[args.length - 1]
@@ -27,7 +27,9 @@ function sequence (gulp) {
 
     if (!args.length) throw new gutil.PluginError(packageName, 'No tasks were provided to gulp-sequence!')
 
-    var runSequence = thunk.seq(args.map(function (task) {
+    var runSequence = thunk.seq(args.filter(function(taskName) {
+      return taskName;
+    }).map(function (task) {
       return function (callback) {
         if (!Array.isArray(task)) task = [task]
 


### PR DESCRIPTION
gulp.task pass if in submodules wrote an <undefined> taskName
gulpSequence should do the same 
For example
`gulp.task('taskName', config.env === 'development' ? [subTaskName] : undefined)`
So in gulpSequence it could be:

```
gulp.task('taskName', gulpSequence(
    config.env === 'development' ? subTaskName1 : undefined,
    [subTaskName2, subTaskName3]
)
```
